### PR TITLE
fix compatibility in php version 8

### DIFF
--- a/src/Calendars/Calendar.php
+++ b/src/Calendars/Calendar.php
@@ -77,7 +77,7 @@ abstract class Calendar
         // Astronomical to civil
         $time = floor(($julianDay - floor($julianDay)) * Constants::DAY_IN_SECONDS);
 
-        return new Time(floor($time / Constants::HOUR_IN_SECONDS), floor(($time / Constants::MINUTES_PER_HOUR) % Constants::SECONDS_PER_MINUTE), floor($time % Constants::SECONDS_PER_MINUTE));
+        return new Time(floor($time / Constants::HOUR_IN_SECONDS), floor($time / Constants::MINUTES_PER_HOUR) % Constants::SECONDS_PER_MINUTE, floor($time % Constants::SECONDS_PER_MINUTE));
     }
 
     /**


### PR DESCRIPTION
hi,
According to php upgrade it is not possible to take the remainder of a decimal number.
now compatible with php version 8.
thanks for your attention.